### PR TITLE
docs: 修复部署中Netlify的标题

### DIFF
--- a/docs/deployment/Netlify.md
+++ b/docs/deployment/Netlify.md
@@ -1,4 +1,4 @@
-# PM2
+# Netlify
 
 如何将 Nuxt 部署到 Netlify 服务。
 


### PR DESCRIPTION
deployment中Netlify.md中的标题为PM2，应修改为Netlify